### PR TITLE
Improve Posts Layout

### DIFF
--- a/pages/posts/[slug].tsx
+++ b/pages/posts/[slug].tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import * as postsService from '../../lib/posts';
 import PostType from '../../lib/types/post';
 
@@ -6,10 +7,19 @@ interface PropTypes {
 }
 
 const Post = ({ post }: PropTypes) => (
-  <div>
-    <h1>{post.data.title}</h1>
+  <div className="container mx-auto">
+    <div className=" text-center font-black text-3xl m-12">
+      <h1>{post.data.title}</h1>
+    </div>
     <span>slug: {post.slug}</span>
     <div dangerouslySetInnerHTML={{ __html: post.content }} />
+    <div className="hover:underline my-4">
+      <h2>
+        <Link href="/">
+          <a>Back to home</a>
+        </Link>
+      </h2>
+    </div>
   </div>
 );
 


### PR DESCRIPTION
The following PR adds some minor improvements for the posts layout.

![example](https://user-images.githubusercontent.com/13787741/99889010-5107b500-2c1f-11eb-9478-138c9c538966.gif)

I left that span element that's holding the post's slug for testing purposes (might come in handy just to validate the urls once we have several posts). We can get rid of it at anytime anyways.